### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/scripts/use_mock_atlas_scalar.py
+++ b/scripts/use_mock_atlas_scalar.py
@@ -96,6 +96,9 @@ def main():
     parser.add_argument(
         "-v", "--verbose", help="increase output verbosity", action="store_true"
     )
+    parser.add_argument(
+        "--version", action="version", version=f"%(prog)s {wfc.__version__}"
+    )
     args = parser.parse_args()
 
     # Setup logging

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,25 @@
 #!/usr/bin/env python
 
+import os
 from distutils.command.build_ext import build_ext
 from distutils.core import Extension, setup
+
+
+def read(rel_path: str) -> str:
+    here = os.path.abspath(os.path.dirname(__file__))
+    # intentionally *not* adding an encoding option to open, See:
+    #   https://github.com/pypa/virtualenv/issues/201#issuecomment-3145690
+    with open(os.path.join(here, rel_path)) as fp:
+        return fp.read()
+
+
+def get_version(rel_path: str) -> str:
+    for line in read(rel_path).splitlines():
+        if line.startswith("__version__"):
+            # __version__ = "0.9"
+            delim = '"' if '"' in line else "'"
+            return line.split(delim)[1]
+    raise RuntimeError("Unable to find version string.")
 
 
 class CustomBuildExtCommand(build_ext):
@@ -36,7 +54,7 @@ _convolution = Extension(
 setup(
     cmdclass={"build_ext": CustomBuildExtCommand},
     name="wormfunconn",
-    version="0.1",
+    version=get_version("wormfunconn/__init__.py"),
     description="Functional connectivity atlas for the C. elegans brain",
     author="Francesco Randi",
     author_email="francesco.randi@gmail.com",

--- a/wormfunconn/__init__.py
+++ b/wormfunconn/__init__.py
@@ -1,6 +1,8 @@
 __all__ = ['integral','integral_py','convolution1','convolution',
            'FunctionalAtlas','exp_conv_2','exp_conv_2b']
 
+__version__ = "0.1.1"
+
 from ._integration import integral
 from .integration import integral as integral_py
 from ._convolution import convolution1, convolution


### PR DESCRIPTION
Bump the version to make automated installations recognize the change.

Set the version in module and use that as the single source of truth for the module version (source: https://packaging.python.org/guides/single-sourcing-package-version/)

Report the version in the command line script.