### PR TITLE
Specify dtype for ragged array

### DIFF
--- a/wormfunconn/integration.py
+++ b/wormfunconn/integration.py
@@ -46,7 +46,7 @@ gregory_omega = np.array([
               7.02145337301587301590e-01,
               1.07249696869488536160e+00,
               9.92107445987654320990e-01])
-    ])
+    ], dtype=object)
     
 def integral(Y, dx=1., k=8):
     '''Computes the integral of Y sampled on equispaced abscissas, using the 


### PR DESCRIPTION
Newer versions of numpy require `dtype=object` for ragged arrays. Deprecation started in release 1.19. See [Release notes for 1.19.0](https://numpy.org/doc/1.19/release/1.19.0-notes.html#deprecate-automatic-dtype-object-for-ragged-input) and [NEP 34 — Disallow inferring dtype=object from sequences](https://numpy.org/neps/nep-0034-infer-dtype-is-object.html).

Resolves #12 