### PR TITLE
Added pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["wheel", "setuptools", "oldest-supported-numpy"]


### PR DESCRIPTION
Adding this `pyproject.toml` allows us to have a build-time dependency. See https://numpy.org/doc/1.24/dev/depending_on_numpy.html#build-time-dependency and https://github.com/scipy/oldest-supported-numpy/ for more information.

Resolves #11 